### PR TITLE
Rename 'job' to 'command'

### DIFF
--- a/client.go
+++ b/client.go
@@ -4,7 +4,6 @@ package rce
 
 import (
 	"crypto/tls"
-	"fmt"
 	"io"
 	"time"
 
@@ -14,67 +13,41 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
-// Interface for sending commands to the remote agent
+// A Client is used to send commands to a remote agent.
 type Client interface {
+	// Open the connection to the agent
+	Open(host, port string) error
 
-	// Get All jobs that have been submitted after the input time
-	GetJobs(since time.Time) ([]uint64, error)
+	// Closes the connection to the agent.
+	Close() error
 
-	// Get the status of the given job id.
-	// An error is returned if the jobid does not exist
-	GetJobStatus(jobID uint64) (*JobStatus, error)
+	// Get All commandss that have been submitted after the input time
+	GetCommands(since time.Time) ([]uint64, error)
 
-	// Starts a job. This is a non-blocking operation.
-	// A job status will be returned immediately. It is up to the
+	// Get the status of the given cmd id.
+	// An error is returned if the cmdid does not exist
+	GetCommandStatus(cmdID uint64) (*pb.CommandStatus, error)
+
+	// Starts a cmd. This is a non-blocking operation.
+	// A cmd status will be returned immediately. It is up to the
 	// client user to continuously poll for status.
-	StartJob(jobName, jobCommand string, args []string) (*JobStatus, error)
+	StartCommand(cmdName string, args []string) (*pb.CommandStatus, error)
 
-	// Stops a job given the job id.
-	// If the job id is not found, or the job is not currently running,
+	// Stops a cmd given the cmd id.
+	// If the cmd id is not found, or the cmd is not currently running,
 	// a non-nil error will be returned.
-	// This will issue a SIGTERM signal to the running job. The job status
-	// of that job will be returned. Because that job is killed with a SIGTERM
+	// This will issue a SIGTERM signal to the running cmd. The cmd status
+	// of that cmd will be returned. Because that cmd is killed with a SIGTERM
 	// the exit code will not be available.
-	StopJob(jobID uint64) (*JobStatus, error)
+	StopCommand(cmdID uint64) (*pb.CommandStatus, error)
 
 	// Get the hostname of the agent that the client is connected to.
 	GetAgentHostname() string
 
 	// Get the port of the agent that the client is connected to.
 	GetAgentPort() string
-
-	// Open the connection to the agent
-	Open(host, port string) error
-
-	// Closes the connection to the agent.
-	Close() error
 }
 
-type JobStatus struct {
-	Hostname    string   // hostname that the job ran on
-	Port        string   // port through which the agent is listening
-	JobID       uint64   // id of this job (this is not necessarily unique across all hosts
-	JobName     string   // user provided name for this job (for easy identification)
-	Pid         int64    // PID of the job that ran/is running
-	Status      int64    // State of the job: not yet started, running, completed
-	CommandName string   // The name for the command requested
-	StartTime   int64    // Start time of job in unix time
-	FinishTime  int64    // finish time of job in unix time. Will be 0 if not yet finished
-	ExitCode    int64    // Exit code of the command. -1 if the command has not yet finished or is signaled
-	Args        []string // Arguments to command
-	Stdout      []string // stdout from the command.
-	Stderr      []string // stderr from the command.
-	Error       string   // Error (From running the command)
-}
-
-// TODO: use this if it turns out to be cleaner than passing in individual args
-type JobRequest struct {
-	JobName     string
-	CommandName string
-	Arguments   []string
-}
-
-// non-exported intentionally
 type client struct {
 	host      string
 	port      string
@@ -126,25 +99,25 @@ func (c *client) GetAgentPort() string {
 	return c.port
 }
 
-// Queries the agent for all JobIDs that have been submitted before the input time.
-// Agents (currently) do not persist job data between restarts, so any jobs
+// Queries the agent for all CommandIDs that have been submitted before the input time.
+// Agents (currently) do not persist cmd data between restarts, so any cmds
 // that have occured prior to the most recent start will not be returned.
-func (c *client) GetJobs(since time.Time) ([]uint64, error) {
+func (c *client) GetCommands(since time.Time) ([]uint64, error) {
 	startTime := &pb.StartTime{
 		StartTime: since.Unix(),
 	}
 
-	jobs := []uint64{}
+	cmds := []uint64{}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	stream, err := c.agent.GetJobs(ctx, startTime)
+	stream, err := c.agent.GetCommands(ctx, startTime)
 	if err != nil {
 		return nil, err
 	}
 
 	for {
-		jobStatus, err := stream.Recv()
+		cmdStatus, err := stream.Recv()
 		if err == io.EOF {
 			break
 		}
@@ -152,108 +125,55 @@ func (c *client) GetJobs(since time.Time) ([]uint64, error) {
 			return nil, err
 		}
 
-		jobs = append(jobs, jobStatus.JobID)
+		cmds = append(cmds, cmdStatus.CommandID)
 	}
 
-	return jobs, nil
+	return cmds, nil
 }
 
-// Given the id of a job, return the status of that job.
-// A nil JobStatus and a non-nil error will be returned if the
-// job cannot be found.
-func (c *client) GetJobStatus(jobID uint64) (*JobStatus, error) {
-	req := &pb.JobID{
-		JobID: jobID,
+// Given the id of a cmd, return the status of that cmd.
+// A nil CommandStatus and a non-nil error will be returned if the
+// cmd cannot be found.
+func (c *client) GetCommandStatus(cmdID uint64) (*pb.CommandStatus, error) {
+	req := &pb.CommandID{
+		CommandID: cmdID,
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	status, err := c.agent.GetJobStatus(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-
-	jobStatus := c.getJobStatus(status)
-	return jobStatus, nil
+	return c.agent.GetCommandStatus(ctx, req)
 }
 
-// Given the id of a job, stop that job. If the job is not found, or the job
-// is not currently running. A non-nil error will be returned, and JobStatus will
+// Given the id of a cmd, stop that cmd. If the cmd is not found, or the cmd
+// is not currently running. A non-nil error will be returned, and CommandStatus will
 // be nil.
-func (c *client) StopJob(jobID uint64) (*JobStatus, error) {
-	req := &pb.JobID{
-		JobID: jobID,
+func (c *client) StopCommand(cmdID uint64) (*pb.CommandStatus, error) {
+	req := &pb.CommandID{
+		CommandID: cmdID,
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	status, err := c.agent.StopJob(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-
-	jobStatus := c.getJobStatus(status)
-	return jobStatus, nil
+	return c.agent.StopCommand(ctx, req)
 }
 
-// Start a given job.
-// TODO: consider taking a JobRequest struct as input instead
-func (c *client) StartJob(jobName string, jobCommand string, args []string) (*JobStatus, error) {
-	request := &pb.JobRequest{
-		JobName:     jobName,
-		CommandName: jobCommand,
+// Start a given cmd.
+// TODO: consider taking a CommandRequest struct as input instead
+func (c *client) StartCommand(cmdName string, args []string) (*pb.CommandStatus, error) {
+	request := &pb.CommandRequest{
+		CommandName: cmdName,
 		Arguments:   args,
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	status, err := c.agent.StartJob(ctx, request)
+	status, err := c.agent.StartCommand(ctx, request)
 	if err != nil {
 		return nil, err
 	}
 
-	jobStatus := c.getJobStatus(status)
-	return jobStatus, nil
-}
-
-// Given a pb.JobStatus, convert that into the JobStatus for the user
-func (c *client) getJobStatus(s *pb.JobStatus) *JobStatus {
-	jobStatus := &JobStatus{
-		Hostname:    c.host,
-		Port:        c.port,
-		JobID:       s.JobID,
-		JobName:     s.JobName,
-		Pid:         s.PID,
-		Status:      s.Status,
-		CommandName: s.CommandName,
-		StartTime:   s.StartTime,
-		FinishTime:  s.FinishTime,
-		ExitCode:    s.ExitCode,
-		Args:        s.Args,
-		Stdout:      s.Stdout,
-		Stderr:      s.Stderr,
-		Error:       s.Error,
-	}
-	return jobStatus
-}
-
-// Prints job status to stdout. A useful debugging tool.
-func (js *JobStatus) Print() {
-	fmt.Printf("Hostname    %v \n", js.Hostname)
-	fmt.Printf("Port        %v \n", js.Port)
-	fmt.Printf("JobName     %v \n", js.JobName)
-	fmt.Printf("JobID       %v \n", js.JobID)
-	fmt.Printf("PID         %v \n", js.Pid)
-	fmt.Printf("Status      %v \n", js.Status)
-	fmt.Printf("CommandName %v \n", js.CommandName)
-	fmt.Printf("StartTime   %v \n", js.StartTime)
-	fmt.Printf("FinishTime  %v \n", js.FinishTime)
-	fmt.Printf("ExitCode    %v \n", js.ExitCode)
-	fmt.Printf("Args        %v \n", js.Args)
-	fmt.Printf("Stdout      %v \n", js.Stdout)
-	fmt.Printf("Stderr      %v \n", js.Stderr)
-	fmt.Printf("Error       %v \n", js.Error)
+	return c.GetCommandStatus(status.CommandID)
 }

--- a/command_test.go
+++ b/command_test.go
@@ -7,9 +7,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	yaml "gopkg.in/yaml.v2"
-
 	"github.com/go-test/deep"
+	yaml "gopkg.in/yaml.v2"
 )
 
 var err error

--- a/pb/rce.pb.go
+++ b/pb/rce.pb.go
@@ -10,9 +10,9 @@ It is generated from these files:
 
 It has these top-level messages:
 	StartTime
-	JobStatus
-	JobID
-	JobRequest
+	CommandStatus
+	CommandID
+	CommandRequest
 */
 package pb
 
@@ -52,152 +52,136 @@ func (m *StartTime) GetStartTime() int64 {
 	return 0
 }
 
-type JobStatus struct {
-	JobID       uint64   `protobuf:"varint,1,opt,name=JobID" json:"JobID,omitempty"`
-	JobName     string   `protobuf:"bytes,2,opt,name=JobName" json:"JobName,omitempty"`
-	Status      int64    `protobuf:"varint,3,opt,name=Status" json:"Status,omitempty"`
-	CommandName string   `protobuf:"bytes,4,opt,name=CommandName" json:"CommandName,omitempty"`
-	PID         int64    `protobuf:"varint,5,opt,name=PID" json:"PID,omitempty"`
-	StartTime   int64    `protobuf:"varint,6,opt,name=StartTime" json:"StartTime,omitempty"`
-	FinishTime  int64    `protobuf:"varint,7,opt,name=FinishTime" json:"FinishTime,omitempty"`
-	ExitCode    int64    `protobuf:"varint,8,opt,name=ExitCode" json:"ExitCode,omitempty"`
-	Args        []string `protobuf:"bytes,9,rep,name=Args" json:"Args,omitempty"`
-	Stdout      []string `protobuf:"bytes,10,rep,name=Stdout" json:"Stdout,omitempty"`
-	Stderr      []string `protobuf:"bytes,11,rep,name=Stderr" json:"Stderr,omitempty"`
-	Error       string   `protobuf:"bytes,12,opt,name=Error" json:"Error,omitempty"`
+type CommandStatus struct {
+	CommandID   uint64   `protobuf:"varint,1,opt,name=CommandID" json:"CommandID,omitempty"`
+	Status      int64    `protobuf:"varint,2,opt,name=Status" json:"Status,omitempty"`
+	CommandName string   `protobuf:"bytes,3,opt,name=CommandName" json:"CommandName,omitempty"`
+	PID         int64    `protobuf:"varint,4,opt,name=PID" json:"PID,omitempty"`
+	StartTime   int64    `protobuf:"varint,5,opt,name=StartTime" json:"StartTime,omitempty"`
+	FinishTime  int64    `protobuf:"varint,6,opt,name=FinishTime" json:"FinishTime,omitempty"`
+	ExitCode    int64    `protobuf:"varint,7,opt,name=ExitCode" json:"ExitCode,omitempty"`
+	Args        []string `protobuf:"bytes,8,rep,name=Args" json:"Args,omitempty"`
+	Stdout      []string `protobuf:"bytes,9,rep,name=Stdout" json:"Stdout,omitempty"`
+	Stderr      []string `protobuf:"bytes,10,rep,name=Stderr" json:"Stderr,omitempty"`
+	Error       string   `protobuf:"bytes,11,opt,name=Error" json:"Error,omitempty"`
 }
 
-func (m *JobStatus) Reset()                    { *m = JobStatus{} }
-func (m *JobStatus) String() string            { return proto.CompactTextString(m) }
-func (*JobStatus) ProtoMessage()               {}
-func (*JobStatus) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{1} }
+func (m *CommandStatus) Reset()                    { *m = CommandStatus{} }
+func (m *CommandStatus) String() string            { return proto.CompactTextString(m) }
+func (*CommandStatus) ProtoMessage()               {}
+func (*CommandStatus) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{1} }
 
-func (m *JobStatus) GetJobID() uint64 {
+func (m *CommandStatus) GetCommandID() uint64 {
 	if m != nil {
-		return m.JobID
+		return m.CommandID
 	}
 	return 0
 }
 
-func (m *JobStatus) GetJobName() string {
-	if m != nil {
-		return m.JobName
-	}
-	return ""
-}
-
-func (m *JobStatus) GetStatus() int64 {
+func (m *CommandStatus) GetStatus() int64 {
 	if m != nil {
 		return m.Status
 	}
 	return 0
 }
 
-func (m *JobStatus) GetCommandName() string {
+func (m *CommandStatus) GetCommandName() string {
 	if m != nil {
 		return m.CommandName
 	}
 	return ""
 }
 
-func (m *JobStatus) GetPID() int64 {
+func (m *CommandStatus) GetPID() int64 {
 	if m != nil {
 		return m.PID
 	}
 	return 0
 }
 
-func (m *JobStatus) GetStartTime() int64 {
+func (m *CommandStatus) GetStartTime() int64 {
 	if m != nil {
 		return m.StartTime
 	}
 	return 0
 }
 
-func (m *JobStatus) GetFinishTime() int64 {
+func (m *CommandStatus) GetFinishTime() int64 {
 	if m != nil {
 		return m.FinishTime
 	}
 	return 0
 }
 
-func (m *JobStatus) GetExitCode() int64 {
+func (m *CommandStatus) GetExitCode() int64 {
 	if m != nil {
 		return m.ExitCode
 	}
 	return 0
 }
 
-func (m *JobStatus) GetArgs() []string {
+func (m *CommandStatus) GetArgs() []string {
 	if m != nil {
 		return m.Args
 	}
 	return nil
 }
 
-func (m *JobStatus) GetStdout() []string {
+func (m *CommandStatus) GetStdout() []string {
 	if m != nil {
 		return m.Stdout
 	}
 	return nil
 }
 
-func (m *JobStatus) GetStderr() []string {
+func (m *CommandStatus) GetStderr() []string {
 	if m != nil {
 		return m.Stderr
 	}
 	return nil
 }
 
-func (m *JobStatus) GetError() string {
+func (m *CommandStatus) GetError() string {
 	if m != nil {
 		return m.Error
 	}
 	return ""
 }
 
-type JobID struct {
-	JobID uint64 `protobuf:"varint,1,opt,name=JobID" json:"JobID,omitempty"`
+type CommandID struct {
+	CommandID uint64 `protobuf:"varint,1,opt,name=CommandID" json:"CommandID,omitempty"`
 }
 
-func (m *JobID) Reset()                    { *m = JobID{} }
-func (m *JobID) String() string            { return proto.CompactTextString(m) }
-func (*JobID) ProtoMessage()               {}
-func (*JobID) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{2} }
+func (m *CommandID) Reset()                    { *m = CommandID{} }
+func (m *CommandID) String() string            { return proto.CompactTextString(m) }
+func (*CommandID) ProtoMessage()               {}
+func (*CommandID) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{2} }
 
-func (m *JobID) GetJobID() uint64 {
+func (m *CommandID) GetCommandID() uint64 {
 	if m != nil {
-		return m.JobID
+		return m.CommandID
 	}
 	return 0
 }
 
-type JobRequest struct {
-	JobName     string   `protobuf:"bytes,1,opt,name=JobName" json:"JobName,omitempty"`
-	CommandName string   `protobuf:"bytes,2,opt,name=CommandName" json:"CommandName,omitempty"`
-	Arguments   []string `protobuf:"bytes,3,rep,name=Arguments" json:"Arguments,omitempty"`
+type CommandRequest struct {
+	CommandName string   `protobuf:"bytes,1,opt,name=CommandName" json:"CommandName,omitempty"`
+	Arguments   []string `protobuf:"bytes,2,rep,name=Arguments" json:"Arguments,omitempty"`
 }
 
-func (m *JobRequest) Reset()                    { *m = JobRequest{} }
-func (m *JobRequest) String() string            { return proto.CompactTextString(m) }
-func (*JobRequest) ProtoMessage()               {}
-func (*JobRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{3} }
+func (m *CommandRequest) Reset()                    { *m = CommandRequest{} }
+func (m *CommandRequest) String() string            { return proto.CompactTextString(m) }
+func (*CommandRequest) ProtoMessage()               {}
+func (*CommandRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{3} }
 
-func (m *JobRequest) GetJobName() string {
-	if m != nil {
-		return m.JobName
-	}
-	return ""
-}
-
-func (m *JobRequest) GetCommandName() string {
+func (m *CommandRequest) GetCommandName() string {
 	if m != nil {
 		return m.CommandName
 	}
 	return ""
 }
 
-func (m *JobRequest) GetArguments() []string {
+func (m *CommandRequest) GetArguments() []string {
 	if m != nil {
 		return m.Arguments
 	}
@@ -206,9 +190,9 @@ func (m *JobRequest) GetArguments() []string {
 
 func init() {
 	proto.RegisterType((*StartTime)(nil), "rce.StartTime")
-	proto.RegisterType((*JobStatus)(nil), "rce.JobStatus")
-	proto.RegisterType((*JobID)(nil), "rce.JobID")
-	proto.RegisterType((*JobRequest)(nil), "rce.JobRequest")
+	proto.RegisterType((*CommandStatus)(nil), "rce.CommandStatus")
+	proto.RegisterType((*CommandID)(nil), "rce.CommandID")
+	proto.RegisterType((*CommandRequest)(nil), "rce.CommandRequest")
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -222,15 +206,15 @@ const _ = grpc.SupportPackageIsVersion4
 // Client API for RCEAgent service
 
 type RCEAgentClient interface {
-	// Call to get all jobs currently active on rce agent
-	GetJobs(ctx context.Context, in *StartTime, opts ...grpc.CallOption) (RCEAgent_GetJobsClient, error)
-	// Call to get the status of a particular job that may or
+	// Start a Specific Command
+	StartCommand(ctx context.Context, in *CommandRequest, opts ...grpc.CallOption) (*CommandStatus, error)
+	// Call to get the status of a particular command that may or
 	// may not be currently Active on the host
-	GetJobStatus(ctx context.Context, in *JobID, opts ...grpc.CallOption) (*JobStatus, error)
-	// Start a Specific Job
-	StartJob(ctx context.Context, in *JobRequest, opts ...grpc.CallOption) (*JobStatus, error)
-	// Stop an already Running Job. This will be an "ungraceful" kill
-	StopJob(ctx context.Context, in *JobID, opts ...grpc.CallOption) (*JobStatus, error)
+	GetCommandStatus(ctx context.Context, in *CommandID, opts ...grpc.CallOption) (*CommandStatus, error)
+	// Call to get all commands currently active on rce agent
+	GetCommands(ctx context.Context, in *StartTime, opts ...grpc.CallOption) (RCEAgent_GetCommandsClient, error)
+	// Stop an already Running Command. This will be an "ungraceful" kill
+	StopCommand(ctx context.Context, in *CommandID, opts ...grpc.CallOption) (*CommandStatus, error)
 }
 
 type rCEAgentClient struct {
@@ -241,12 +225,30 @@ func NewRCEAgentClient(cc *grpc.ClientConn) RCEAgentClient {
 	return &rCEAgentClient{cc}
 }
 
-func (c *rCEAgentClient) GetJobs(ctx context.Context, in *StartTime, opts ...grpc.CallOption) (RCEAgent_GetJobsClient, error) {
-	stream, err := grpc.NewClientStream(ctx, &_RCEAgent_serviceDesc.Streams[0], c.cc, "/rce.RCEAgent/GetJobs", opts...)
+func (c *rCEAgentClient) StartCommand(ctx context.Context, in *CommandRequest, opts ...grpc.CallOption) (*CommandStatus, error) {
+	out := new(CommandStatus)
+	err := grpc.Invoke(ctx, "/rce.RCEAgent/StartCommand", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
-	x := &rCEAgentGetJobsClient{stream}
+	return out, nil
+}
+
+func (c *rCEAgentClient) GetCommandStatus(ctx context.Context, in *CommandID, opts ...grpc.CallOption) (*CommandStatus, error) {
+	out := new(CommandStatus)
+	err := grpc.Invoke(ctx, "/rce.RCEAgent/GetCommandStatus", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *rCEAgentClient) GetCommands(ctx context.Context, in *StartTime, opts ...grpc.CallOption) (RCEAgent_GetCommandsClient, error) {
+	stream, err := grpc.NewClientStream(ctx, &_RCEAgent_serviceDesc.Streams[0], c.cc, "/rce.RCEAgent/GetCommands", opts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &rCEAgentGetCommandsClient{stream}
 	if err := x.ClientStream.SendMsg(in); err != nil {
 		return nil, err
 	}
@@ -256,44 +258,26 @@ func (c *rCEAgentClient) GetJobs(ctx context.Context, in *StartTime, opts ...grp
 	return x, nil
 }
 
-type RCEAgent_GetJobsClient interface {
-	Recv() (*JobID, error)
+type RCEAgent_GetCommandsClient interface {
+	Recv() (*CommandID, error)
 	grpc.ClientStream
 }
 
-type rCEAgentGetJobsClient struct {
+type rCEAgentGetCommandsClient struct {
 	grpc.ClientStream
 }
 
-func (x *rCEAgentGetJobsClient) Recv() (*JobID, error) {
-	m := new(JobID)
+func (x *rCEAgentGetCommandsClient) Recv() (*CommandID, error) {
+	m := new(CommandID)
 	if err := x.ClientStream.RecvMsg(m); err != nil {
 		return nil, err
 	}
 	return m, nil
 }
 
-func (c *rCEAgentClient) GetJobStatus(ctx context.Context, in *JobID, opts ...grpc.CallOption) (*JobStatus, error) {
-	out := new(JobStatus)
-	err := grpc.Invoke(ctx, "/rce.RCEAgent/GetJobStatus", in, out, c.cc, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func (c *rCEAgentClient) StartJob(ctx context.Context, in *JobRequest, opts ...grpc.CallOption) (*JobStatus, error) {
-	out := new(JobStatus)
-	err := grpc.Invoke(ctx, "/rce.RCEAgent/StartJob", in, out, c.cc, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func (c *rCEAgentClient) StopJob(ctx context.Context, in *JobID, opts ...grpc.CallOption) (*JobStatus, error) {
-	out := new(JobStatus)
-	err := grpc.Invoke(ctx, "/rce.RCEAgent/StopJob", in, out, c.cc, opts...)
+func (c *rCEAgentClient) StopCommand(ctx context.Context, in *CommandID, opts ...grpc.CallOption) (*CommandStatus, error) {
+	out := new(CommandStatus)
+	err := grpc.Invoke(ctx, "/rce.RCEAgent/StopCommand", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -303,92 +287,92 @@ func (c *rCEAgentClient) StopJob(ctx context.Context, in *JobID, opts ...grpc.Ca
 // Server API for RCEAgent service
 
 type RCEAgentServer interface {
-	// Call to get all jobs currently active on rce agent
-	GetJobs(*StartTime, RCEAgent_GetJobsServer) error
-	// Call to get the status of a particular job that may or
+	// Start a Specific Command
+	StartCommand(context.Context, *CommandRequest) (*CommandStatus, error)
+	// Call to get the status of a particular command that may or
 	// may not be currently Active on the host
-	GetJobStatus(context.Context, *JobID) (*JobStatus, error)
-	// Start a Specific Job
-	StartJob(context.Context, *JobRequest) (*JobStatus, error)
-	// Stop an already Running Job. This will be an "ungraceful" kill
-	StopJob(context.Context, *JobID) (*JobStatus, error)
+	GetCommandStatus(context.Context, *CommandID) (*CommandStatus, error)
+	// Call to get all commands currently active on rce agent
+	GetCommands(*StartTime, RCEAgent_GetCommandsServer) error
+	// Stop an already Running Command. This will be an "ungraceful" kill
+	StopCommand(context.Context, *CommandID) (*CommandStatus, error)
 }
 
 func RegisterRCEAgentServer(s *grpc.Server, srv RCEAgentServer) {
 	s.RegisterService(&_RCEAgent_serviceDesc, srv)
 }
 
-func _RCEAgent_GetJobs_Handler(srv interface{}, stream grpc.ServerStream) error {
+func _RCEAgent_StartCommand_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CommandRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RCEAgentServer).StartCommand(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/rce.RCEAgent/StartCommand",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RCEAgentServer).StartCommand(ctx, req.(*CommandRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _RCEAgent_GetCommandStatus_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CommandID)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RCEAgentServer).GetCommandStatus(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/rce.RCEAgent/GetCommandStatus",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RCEAgentServer).GetCommandStatus(ctx, req.(*CommandID))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _RCEAgent_GetCommands_Handler(srv interface{}, stream grpc.ServerStream) error {
 	m := new(StartTime)
 	if err := stream.RecvMsg(m); err != nil {
 		return err
 	}
-	return srv.(RCEAgentServer).GetJobs(m, &rCEAgentGetJobsServer{stream})
+	return srv.(RCEAgentServer).GetCommands(m, &rCEAgentGetCommandsServer{stream})
 }
 
-type RCEAgent_GetJobsServer interface {
-	Send(*JobID) error
+type RCEAgent_GetCommandsServer interface {
+	Send(*CommandID) error
 	grpc.ServerStream
 }
 
-type rCEAgentGetJobsServer struct {
+type rCEAgentGetCommandsServer struct {
 	grpc.ServerStream
 }
 
-func (x *rCEAgentGetJobsServer) Send(m *JobID) error {
+func (x *rCEAgentGetCommandsServer) Send(m *CommandID) error {
 	return x.ServerStream.SendMsg(m)
 }
 
-func _RCEAgent_GetJobStatus_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(JobID)
+func _RCEAgent_StopCommand_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CommandID)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(RCEAgentServer).GetJobStatus(ctx, in)
+		return srv.(RCEAgentServer).StopCommand(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/rce.RCEAgent/GetJobStatus",
+		FullMethod: "/rce.RCEAgent/StopCommand",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(RCEAgentServer).GetJobStatus(ctx, req.(*JobID))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
-func _RCEAgent_StartJob_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(JobRequest)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(RCEAgentServer).StartJob(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: "/rce.RCEAgent/StartJob",
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(RCEAgentServer).StartJob(ctx, req.(*JobRequest))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
-func _RCEAgent_StopJob_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(JobID)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(RCEAgentServer).StopJob(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: "/rce.RCEAgent/StopJob",
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(RCEAgentServer).StopJob(ctx, req.(*JobID))
+		return srv.(RCEAgentServer).StopCommand(ctx, req.(*CommandID))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -398,22 +382,22 @@ var _RCEAgent_serviceDesc = grpc.ServiceDesc{
 	HandlerType: (*RCEAgentServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
-			MethodName: "GetJobStatus",
-			Handler:    _RCEAgent_GetJobStatus_Handler,
+			MethodName: "StartCommand",
+			Handler:    _RCEAgent_StartCommand_Handler,
 		},
 		{
-			MethodName: "StartJob",
-			Handler:    _RCEAgent_StartJob_Handler,
+			MethodName: "GetCommandStatus",
+			Handler:    _RCEAgent_GetCommandStatus_Handler,
 		},
 		{
-			MethodName: "StopJob",
-			Handler:    _RCEAgent_StopJob_Handler,
+			MethodName: "StopCommand",
+			Handler:    _RCEAgent_StopCommand_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{
 		{
-			StreamName:    "GetJobs",
-			Handler:       _RCEAgent_GetJobs_Handler,
+			StreamName:    "GetCommands",
+			Handler:       _RCEAgent_GetCommands_Handler,
 			ServerStreams: true,
 		},
 	},
@@ -423,28 +407,27 @@ var _RCEAgent_serviceDesc = grpc.ServiceDesc{
 func init() { proto.RegisterFile("rce.proto", fileDescriptor0) }
 
 var fileDescriptor0 = []byte{
-	// 363 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x09, 0x6e, 0x88, 0x02, 0xff, 0x7c, 0x52, 0xd1, 0x4e, 0xc2, 0x40,
-	0x10, 0xa4, 0x14, 0x68, 0xbb, 0x10, 0x34, 0x1b, 0x63, 0x2e, 0x04, 0x4d, 0xd3, 0x17, 0x21, 0x51,
-	0x62, 0xf4, 0x0b, 0x08, 0xa0, 0xa1, 0x0f, 0xc6, 0x14, 0x7f, 0xa0, 0x85, 0x13, 0xfb, 0xd0, 0x1e,
-	0x5e, 0xaf, 0x89, 0xff, 0xc6, 0xcf, 0x99, 0xee, 0x15, 0x28, 0x48, 0x7c, 0xdb, 0x99, 0xd9, 0xdd,
-	0xcc, 0xcd, 0x2d, 0x38, 0x72, 0xc9, 0x47, 0x1b, 0x29, 0x94, 0x40, 0x53, 0x2e, 0xb9, 0x37, 0x04,
-	0x67, 0xa1, 0x42, 0xa9, 0x3e, 0xe2, 0x84, 0x63, 0xbf, 0x02, 0x98, 0xe1, 0x1a, 0x03, 0x33, 0x38,
-	0x10, 0xde, 0xb6, 0x0e, 0x8e, 0x2f, 0xa2, 0x85, 0x0a, 0x55, 0x9e, 0xe1, 0x15, 0x34, 0x7d, 0x11,
-	0xcd, 0xa7, 0xd4, 0xd7, 0x08, 0x34, 0x40, 0x06, 0x96, 0x2f, 0xa2, 0xb7, 0x30, 0xe1, 0xac, 0xee,
-	0x1a, 0x03, 0x27, 0xd8, 0x41, 0xbc, 0x86, 0x96, 0x9e, 0x64, 0x26, 0x2d, 0x2e, 0x11, 0xba, 0xd0,
-	0x9e, 0x88, 0x24, 0x09, 0xd3, 0x15, 0x4d, 0x35, 0x68, 0xaa, 0x4a, 0xe1, 0x25, 0x98, 0xef, 0xf3,
-	0x29, 0x6b, 0xd2, 0x58, 0x51, 0x1e, 0xfb, 0x6c, 0x9d, 0xf8, 0xc4, 0x5b, 0x80, 0x97, 0x38, 0x8d,
-	0xb3, 0x2f, 0x92, 0x2d, 0x92, 0x2b, 0x0c, 0xf6, 0xc0, 0x9e, 0xfd, 0xc4, 0x6a, 0x22, 0x56, 0x9c,
-	0xd9, 0xa4, 0xee, 0x31, 0x22, 0x34, 0xc6, 0x72, 0x9d, 0x31, 0xc7, 0x35, 0x07, 0x4e, 0x40, 0xb5,
-	0x76, 0xbe, 0x12, 0xb9, 0x62, 0x40, 0x6c, 0x89, 0x4a, 0x9e, 0x4b, 0xc9, 0xda, 0x7b, 0x9e, 0x4b,
-	0x59, 0x24, 0x33, 0x93, 0x52, 0x48, 0xd6, 0xa1, 0xb7, 0x68, 0xe0, 0xdd, 0x94, 0x79, 0x9d, 0x0f,
-	0xce, 0xfb, 0x04, 0xf0, 0x45, 0x14, 0xf0, 0xef, 0x9c, 0x67, 0xaa, 0x1a, 0xa3, 0x71, 0x1c, 0xe3,
-	0x49, 0x5c, 0xf5, 0xbf, 0x71, 0xf5, 0xc1, 0x19, 0xcb, 0x75, 0x9e, 0xf0, 0x54, 0x15, 0x59, 0x17,
-	0xce, 0x0e, 0xc4, 0xd3, 0xd6, 0x00, 0x3b, 0x98, 0xcc, 0xc6, 0x6b, 0x9e, 0x2a, 0x1c, 0x82, 0xf5,
-	0xca, 0x95, 0x2f, 0xa2, 0x0c, 0xbb, 0xa3, 0xe2, 0x30, 0xf6, 0x21, 0xf6, 0x80, 0xb0, 0xf6, 0x56,
-	0x7b, 0x34, 0xf0, 0x1e, 0x3a, 0xba, 0xb5, 0xfc, 0xb6, 0x8a, 0xde, 0xeb, 0xee, 0x6a, 0xad, 0x79,
-	0x35, 0x7c, 0x00, 0x9b, 0x56, 0xf9, 0x22, 0xc2, 0x8b, 0x9d, 0x5a, 0x3e, 0xee, 0x4c, 0xfb, 0x1d,
-	0x58, 0x0b, 0x25, 0x36, 0x45, 0xf7, 0xbf, 0x7b, 0xa3, 0x16, 0x5d, 0xee, 0xf3, 0x6f, 0x00, 0x00,
-	0x00, 0xff, 0xff, 0xdd, 0xbb, 0xb2, 0x8e, 0xc6, 0x02, 0x00, 0x00,
+	// 348 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x09, 0x6e, 0x88, 0x02, 0xff, 0x8c, 0x92, 0xc1, 0x4e, 0xc2, 0x40,
+	0x10, 0x86, 0x29, 0x05, 0xa4, 0x53, 0x25, 0x64, 0x34, 0x66, 0x43, 0x88, 0x69, 0x7a, 0xc2, 0x0b,
+	0x51, 0xb9, 0xe8, 0x91, 0x00, 0x1a, 0x2e, 0x86, 0x14, 0x5f, 0xa0, 0xc2, 0x06, 0x7b, 0x68, 0x17,
+	0xa7, 0xd3, 0xc4, 0x97, 0xf2, 0xb9, 0x7c, 0x0d, 0xd3, 0xed, 0x42, 0x0b, 0x46, 0xe3, 0xad, 0xff,
+	0x37, 0x33, 0xbb, 0x7f, 0xff, 0x59, 0x70, 0x68, 0x25, 0x87, 0x5b, 0x52, 0xac, 0xd0, 0xa6, 0x95,
+	0xf4, 0xaf, 0xc1, 0x59, 0x72, 0x48, 0xfc, 0x12, 0xc5, 0x12, 0xfb, 0x15, 0x21, 0x2c, 0xcf, 0x1a,
+	0xd8, 0x41, 0x09, 0xfc, 0xcf, 0x3a, 0x9c, 0x4d, 0x54, 0x1c, 0x87, 0xc9, 0x7a, 0xc9, 0x21, 0x67,
+	0x69, 0xde, 0x6f, 0xc0, 0x7c, 0xaa, 0xfb, 0x1b, 0x41, 0x09, 0xf0, 0x12, 0x5a, 0x45, 0x9f, 0xa8,
+	0xeb, 0xa3, 0x8c, 0x42, 0x0f, 0x5c, 0xd3, 0xf4, 0x1c, 0xc6, 0x52, 0xd8, 0x9e, 0x35, 0x70, 0x82,
+	0x2a, 0xc2, 0x2e, 0xd8, 0x8b, 0xf9, 0x54, 0x34, 0xf4, 0x58, 0xfe, 0x79, 0xe8, 0xac, 0x79, 0xe4,
+	0x0c, 0xaf, 0x00, 0x1e, 0xa3, 0x24, 0x4a, 0xdf, 0x74, 0xb9, 0xa5, 0xcb, 0x15, 0x82, 0x3d, 0x68,
+	0xcf, 0x3e, 0x22, 0x9e, 0xa8, 0xb5, 0x14, 0x27, 0xba, 0xba, 0xd7, 0x88, 0xd0, 0x18, 0xd3, 0x26,
+	0x15, 0x6d, 0xcf, 0x1e, 0x38, 0x81, 0xfe, 0x2e, 0x9c, 0xaf, 0x55, 0xc6, 0xc2, 0xd1, 0xd4, 0x28,
+	0xc3, 0x25, 0x91, 0x80, 0x3d, 0x97, 0x44, 0x78, 0x01, 0xcd, 0x19, 0x91, 0x22, 0xe1, 0xea, 0x7f,
+	0x29, 0x44, 0x1e, 0x6d, 0x19, 0xc6, 0x9f, 0x51, 0xf9, 0x0b, 0xe8, 0x18, 0x11, 0xc8, 0xf7, 0x4c,
+	0xa6, 0x7c, 0x1c, 0x92, 0xf5, 0x33, 0xa4, 0x3e, 0x38, 0x63, 0xda, 0x64, 0xb1, 0x4c, 0x38, 0x4f,
+	0x38, 0xf7, 0x53, 0x82, 0xbb, 0x2f, 0x0b, 0xda, 0xc1, 0x64, 0x36, 0xde, 0xc8, 0x84, 0xf1, 0x01,
+	0x4e, 0x75, 0x58, 0x66, 0x1c, 0xcf, 0x87, 0xf9, 0x2b, 0x38, 0xbc, 0xb1, 0x87, 0x55, 0x58, 0xac,
+	0xca, 0xaf, 0xe1, 0x3d, 0x74, 0x9f, 0x24, 0x1f, 0xae, 0xbd, 0x53, 0xed, 0x9c, 0x4f, 0x7f, 0x99,
+	0xbc, 0x05, 0xb7, 0x9c, 0xdc, 0x0d, 0xed, 0x77, 0xd6, 0x3b, 0x3a, 0xc4, 0xaf, 0xdd, 0x58, 0x38,
+	0x02, 0x77, 0xc9, 0x6a, 0xbb, 0xb3, 0xf9, 0xaf, 0x7b, 0x5e, 0x5b, 0xfa, 0x35, 0x8f, 0xbe, 0x03,
+	0x00, 0x00, 0xff, 0xff, 0x5d, 0xdb, 0xad, 0x50, 0xda, 0x02, 0x00, 0x00,
 }

--- a/pb/rce.proto
+++ b/pb/rce.proto
@@ -6,47 +6,43 @@ package rce;
 
 // Interface exported by the rce agent
 service RCEAgent {
-  // Start a Specific Job
-  rpc StartJob(JobRequest) returns (JobStatus) {}
+  // Start a Specific Command
+  rpc StartCommand(CommandRequest) returns (CommandStatus) {}
 
-  // Call to get the status of a particular job that may or
+  // Call to get the status of a particular command that may or
   // may not be currently Active on the host
-  rpc GetJobStatus(JobID) returns (JobStatus) {}
+  rpc GetCommandStatus(CommandID) returns (CommandStatus) {}
 
-  // Call to get all jobs currently active on rce agent
-  rpc GetJobs(StartTime) returns (stream JobID) {}
+  // Call to get all commands currently active on rce agent
+  rpc GetCommands(StartTime) returns (stream CommandID) {}
 
-  // Stop an already Running Job. This will be an "ungraceful" kill
-  rpc StopJob(JobID) returns (JobStatus) {}
-
-  // TODO: have a job that can stream the output?
+  // Stop an already Running Command. This will be an "ungraceful" kill
+  rpc StopCommand(CommandID) returns (CommandStatus) {}
 }
 
 message StartTime {
   int64 StartTime = 1;
 }
 
-message JobStatus {
-  uint64           JobID =  1;
-  string         JobName =  2; // TODO: Deprecate/delete
-  int64           Status =  3; // TODO: name to "State", define states in this protobuf
-  string     CommandName =  4;
-  int64              PID =  5;
-  int64        StartTime =  6;
-  int64       FinishTime =  7;
-  int64         ExitCode =  8;
-  repeated string   Args =  9;
-  repeated string Stdout = 10;
-  repeated string Stderr = 11;
-  string           Error = 12;
+message CommandStatus {
+  uint64       CommandID =  1;
+  int64           Status =  2; // TODO: name to "State", define states in this protobuf
+  string     CommandName =  3;
+  int64              PID =  4;
+  int64        StartTime =  5;
+  int64       FinishTime =  6;
+  int64         ExitCode =  7;
+  repeated string   Args =  8;
+  repeated string Stdout =  9;
+  repeated string Stderr = 10;
+  string           Error = 11;
 }
 
-message JobID {
-  uint64 JobID = 1;
+message CommandID {
+  uint64 CommandID = 1;
 }
 
-message JobRequest {
-  string            JobName = 1;  // TODO: Deprecate/delete.  This was initially conflated with 'CommandName'
-  string        CommandName = 2;
-  repeated string Arguments = 3;
+message CommandRequest {
+  string        CommandName = 1;
+  repeated string Arguments = 2;
 }

--- a/pb/util.go
+++ b/pb/util.go
@@ -1,0 +1,19 @@
+package pb
+
+import "fmt"
+
+// Prints cmd status to stdout. A useful debugging tool.
+func (s *CommandStatus) Print() {
+	fmt.Printf("CommandName %v \n", s.CommandName)
+	fmt.Printf("CommandID   %v \n", s.CommandID)
+	fmt.Printf("PID         %v \n", s.PID)
+	fmt.Printf("Status      %v \n", s.Status)
+	fmt.Printf("CommandName %v \n", s.CommandName)
+	fmt.Printf("StartTime   %v \n", s.StartTime)
+	fmt.Printf("FinishTime  %v \n", s.FinishTime)
+	fmt.Printf("ExitCode    %v \n", s.ExitCode)
+	fmt.Printf("Args        %v \n", s.Args)
+	fmt.Printf("Stdout      %v \n", s.Stdout)
+	fmt.Printf("Stderr      %v \n", s.Stderr)
+	fmt.Printf("Error       %v \n", s.Error)
+}

--- a/server_test.go
+++ b/server_test.go
@@ -22,24 +22,24 @@ func TestExitZero(t *testing.T) {
 	}
 	t.Logf("server: %+v\n", s)
 
-	jr := &pb.JobRequest{
+	jr := &pb.CommandRequest{
 		CommandName: "exit.zero",
 		Arguments:   []string{},
 	}
 	t.Logf("request: %+v\n", jr)
 
-	status, err := s.StartJob(context.TODO(), jr)
+	status, err := s.StartCommand(context.TODO(), jr)
 	if err != nil {
 		t.Error(err)
 	}
 	t.Logf("initial status: %+v\n", status)
 
-	jobID := &pb.JobID{JobID: status.JobID}
+	cmdID := &pb.CommandID{CommandID: status.CommandID}
 
 	// Wait for it to finish
-	s.WaitOnJob(context.TODO(), jobID)
+	s.WaitOnCommand(context.TODO(), cmdID)
 
-	status, err = s.GetJobStatus(context.TODO(), jobID)
+	status, err = s.GetCommandStatus(context.TODO(), cmdID)
 	t.Logf("status: %+v\nerr: %+v", status, err)
 
 	if status.FinishTime == 0 {
@@ -60,24 +60,24 @@ func TestArgs(t *testing.T) {
 
 	message := "some.message"
 
-	jr := &pb.JobRequest{
+	jr := &pb.CommandRequest{
 		CommandName: "echo",
 		Arguments:   []string{message},
 	}
 	t.Logf("request: %+v\n", jr)
 
-	status, err := s.StartJob(context.TODO(), jr)
+	status, err := s.StartCommand(context.TODO(), jr)
 	if err != nil {
 		t.Error(err)
 	}
 	t.Logf("initial status: %+v\n", status)
 
-	jobID := &pb.JobID{JobID: status.JobID}
+	cmdID := &pb.CommandID{CommandID: status.CommandID}
 
 	// Wait for it to finish
-	s.WaitOnJob(context.TODO(), jobID)
+	s.WaitOnCommand(context.TODO(), cmdID)
 
-	status, err = s.GetJobStatus(context.TODO(), jobID)
+	status, err = s.GetCommandStatus(context.TODO(), cmdID)
 	t.Logf("status: %+v\nerr: %+v", status, err)
 
 	diff := deep.Equal(jr.Arguments, status.Stdout)


### PR DESCRIPTION
* Remove duplicate 'CommandName'
* Use only pb/ structs
* Move `func (s *CommandStatus) Print()` to `pb/util.go`
* Remove `client.getJobStatus()`, consolidated into only `client.GetCommandStatus()`