### PR TITLE
don't register rceagent service with grpc server in NewServer

### DIFF
--- a/server.go
+++ b/server.go
@@ -57,13 +57,15 @@ func NewServer(laddr string, tlsConfig *tls.Config, whitelist cmd.Runnable) Serv
 	} else {
 		grpcServer = grpc.NewServer()
 	}
-	pb.RegisterRCEAgentServer(grpcServer, s)
 	s.grpcServer = grpcServer
 
 	return s
 }
 
 func (s *server) StartServer() error {
+	// Register the RCEAgent service with the gRPC server.
+	pb.RegisterRCEAgentServer(s.grpcServer, s)
+
 	lis, err := net.Listen("tcp", s.laddr)
 	if err != nil {
 		return err

--- a/server.go
+++ b/server.go
@@ -141,11 +141,17 @@ func (s *server) GetStatus(ctx context.Context, id *pb.ID) (*pb.Status, error) {
 	// Get go-cm/cmd.Status struct
 	cmdStatus := cmd.Cmd.Status()
 
+	var errMsg string
+	if cmdStatus.Error != nil {
+		errMsg = cmdStatus.Error.Error()
+	}
+
 	// Make a pb.Status struct by adding and mapping some fields
 	pbStatus := &pb.Status{
 		ID:        cmd.Id,                // add
 		Name:      cmd.Name,              // add
 		ExitCode:  int64(cmdStatus.Exit), // map
+		Error:     errMsg,                // map
 		PID:       int64(cmdStatus.PID),  // map
 		StartTime: cmdStatus.StartTs,     // map
 		StopTime:  cmdStatus.StopTs,      // map


### PR DESCRIPTION
Reason: you should be able to create a new rceagent service without registering it with grpc (useful if you want to register it with your own grpc server)